### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/liuzsen/abcc/compare/v0.1.5...v0.1.6) - 2024-11-15
+
+### Other
+
+- Add test3
+
 ## [0.1.5](https://github.com/liuzsen/abcc/compare/v0.1.4...v0.1.5) - 2024-11-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "tppp"
-version = "0.1.5"
+version = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tppp"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "a test project"


### PR DESCRIPTION
## 🤖 New release
* `tppp`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/liuzsen/abcc/compare/v0.1.5...v0.1.6) - 2024-11-15

### Other

- Add test3
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).