### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/liuzsen/abcc/compare/v0.1.7...v0.1.8) - 2024-11-15
+
+### Other
+
+- Add test5
+
 ## [0.1.7](https://github.com/liuzsen/abcc/compare/v0.1.6...v0.1.7) - 2024-11-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "tppp"
-version = "0.1.7"
+version = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tppp"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "Apache-2.0"
 description = "a test project"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,8 @@ pub fn test3() -> String {
 pub fn test4() -> String {
     "hello".to_string()
 }
+
+/// Returns the string "hello"
+pub fn test5() -> String {
+    "hello".to_string()
+}


### PR DESCRIPTION
## 🤖 New release
* `tppp`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8](https://github.com/liuzsen/abcc/compare/v0.1.7...v0.1.8) - 2024-11-15

### Other

- Add test5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).